### PR TITLE
Add missing Term in OBO

### DIFF
--- a/caloha.obo
+++ b/caloha.obo
@@ -14559,6 +14559,7 @@ xref: FMA:263063
 is_a: TS-3023 ! Small intestine goblet cell
 is_a: TS-1275 ! Duodenum glandular cell
 
+[Term]
 id: TS-3025
 name: Large intestine goblet cell
 def: "A goblet cell that is part of the large intestine." [ GOC:tfm]


### PR DESCRIPTION
When attempting to process caloha.obo, I found that a [Term] declaration was missing, resulting in an error. This PR adds the missing [Term] to fix this. If possible please also look at #2, a more systemic issue with the OBO.