### PR TITLE
Update CALOHA default namespace

### DIFF
--- a/caloha.obo
+++ b/caloha.obo
@@ -3,7 +3,7 @@ data-version: 1.8
 date: 06:01:2022 12:00
 saved-by: pduek
 auto-generated-by: OBO-Edit 2.3
-default-namespace: TS
+default-namespace: CALOHA
 remark: This is a beta version and is only for experimental implementation. This work is copyright the SIB Swiss Institute of Bioinformatics. It is licensed under the Creative Commons Attribution 4.0 International Public License (CC BY 4.0). See: https://creativecommons.org/licenses/by/4.0/
 CALOHA: CALIPHO group Ontology of Human Anatomy
 


### PR DESCRIPTION
CC @paulacalipho 

This PR updates the CALOHA default namespace annotation at the top of the OBO document to match changes in 5900c91